### PR TITLE
fix: load civic tech dc icon from base url

### DIFF
--- a/congressional-insight-explorer/index.html
+++ b/congressional-insight-explorer/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/civictechdc.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%civictechdc.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Congressional Insight Explorer - Interactive Knowledge Graph</title>
     <meta name="description" content="Explore the interconnected themes of modern congressional committee operations through an interactive knowledge graph visualization." />

--- a/congressional-insight-explorer/src/components/Layout/Header.tsx
+++ b/congressional-insight-explorer/src/components/Layout/Header.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
 import { Search, Info, Github, Download, X } from 'lucide-react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { getPublicAssetUrl } from '../../lib/utils';
+
+const civicTechLogoUrl = getPublicAssetUrl('civictechdc.svg');
+const datasetDownloadUrl = getPublicAssetUrl('files/modern_comm_2025.zip');
 
 interface HeaderProps {
   onSearchClick: () => void;
@@ -20,7 +24,7 @@ export const Header: React.FC<HeaderProps> = ({ onSearchClick }) => {
           {/* Logo and Title */}
           <div className="flex items-center gap-4">
             <div className="w-10 h-10 bg-white/20 rounded-lg flex items-center justify-center overflow-hidden">
-              <img src="/civictechdc.svg" alt="Civic Tech DC" className="w-8 h-8" />
+              <img src={civicTechLogoUrl} alt="Civic Tech DC" className="w-8 h-8" />
             </div>
             <div>
               <h1 className="text-xl font-heading font-bold">
@@ -35,7 +39,7 @@ export const Header: React.FC<HeaderProps> = ({ onSearchClick }) => {
           {/* Actions */}
           <div className="flex items-center gap-3">
             <a
-              href="/files/modern_comm_2025.zip"
+              href={datasetDownloadUrl}
               download
               className="flex items-center gap-2 px-3 py-2 bg-white/20 hover:bg-white/30 rounded-lg text-sm font-medium transition-colors"
               aria-label="Download Modern Communications data"

--- a/congressional-insight-explorer/src/components/Layout/TopBar.tsx
+++ b/congressional-insight-explorer/src/components/Layout/TopBar.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import { getPublicAssetUrl } from '../../lib/utils';
+
+const civicTechLogoUrl = getPublicAssetUrl('civictechdc.svg');
 
 export const TopBar: React.FC = () => {
   return (
@@ -6,7 +9,7 @@ export const TopBar: React.FC = () => {
       <div className="container mx-auto px-4 py-1">
         <div className="flex items-center justify-center gap-2">
           <a href="https://civictechdc.org" target="_blank" rel="noopener noreferrer" aria-label="Civic Tech DC website">
-            <img src="/civictechdc.svg" alt="Civic Tech DC" className="w-4 h-4" />
+            <img src={civicTechLogoUrl} alt="Civic Tech DC" className="w-4 h-4" />
           </a>
           <p className="text-xs">
             Built by{' '}

--- a/congressional-insight-explorer/src/lib/utils.ts
+++ b/congressional-insight-explorer/src/lib/utils.ts
@@ -22,7 +22,14 @@ export function getAuthorInitials(name: string): string {
 
 export function highlightSearchMatch(text: string, query: string): string {
   if (!query) return text;
-  
+
   const regex = new RegExp(`(${query})`, 'gi');
   return text.replace(regex, '<mark class="bg-accent-amber/30">$1</mark>');
+}
+
+export function getPublicAssetUrl(path: string): string {
+  const baseUrl = import.meta.env.BASE_URL ?? '/';
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
+  return `${normalizedBase}${normalizedPath}`;
 }


### PR DESCRIPTION
## Summary
- add a utility helper to generate public asset URLs that respect the configured base path
- update the header, top bar, and favicon link to load the Civic Tech DC assets via the helper so they work on GitHub Pages

## Testing
- npm run lint *(fails: existing lint violations in untouched files)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceb1195c108330bfbc6acbd9211f7b